### PR TITLE
Fixed class name and example path

### DIFF
--- a/auth-user-pass-verify.example.php
+++ b/auth-user-pass-verify.example.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__FILE__) . '/vendor/autoload.php';
+require_once dirname(__FILE__) . '/src/vendor/autoload.php';
 
 /**
  * 

--- a/src/Libraries/OneLogin/Methods/SamlAssertion.php
+++ b/src/Libraries/OneLogin/Methods/SamlAssertion.php
@@ -70,8 +70,8 @@ class SamlAssertion implements Method {
                                 }
 
                                 $responseData = $response->getJson()->data[0];
-                                if (\OneVPN\OpenVPNAuth::MFA_AUTH_REQUIRED === true) {
-                                    return VerifyFactor::request(self::$apiToken, $responseData->devices[0]->device_id, $responseData->state_token, \OneVPN\OpenVPNAuth::getAuthArgs()->getMFACode());
+                                if (\OneVPN\Authorize::MFA_AUTH_REQUIRED === true) {
+                                    return VerifyFactor::request(self::$apiToken, $responseData->devices[0]->device_id, $responseData->state_token, \OneVPN\Authorize::getAuthArgs()->getMFACode());
                                 } else {
                                     return true;
                                 }


### PR DESCRIPTION
- Looks like `Authorize` class was renamed.
- The path to the vendor dir in the example `auth-user-pass-verify` should be in src since that is where the composer.json is
